### PR TITLE
Add dependency tracking badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ rewire does **not** load the file and eval the contents to emulate node's requir
 Furthermore rewire comes also with support for various client-side bundlers (see [below](#client-side-bundlers)).
 
 [![Build Status](https://secure.travis-ci.org/jhnns/rewire.png?branch=master)](http://travis-ci.org/jhnns/rewire)
-[![Dependency Status](http://david-dm.org/nisaacson/rewire/status.png)](http://david-dm.org/nisaacson/rewire)
+[![Dependency Status](http://david-dm.org/jhnns/rewire/status.png)](http://david-dm.org/jhnns/rewire)
 Dependency tracking by [David](http://david-dm.org/)
 
 <br />


### PR DESCRIPTION
I made a small change to the readme to include a badge indicating whether dependencies are up to date or not.

See more here [http://david-dm.org/](http://david-dm.org/)
