### PR TITLE
support module that without last empty line

### DIFF
--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -37,7 +37,8 @@ function internalRewire(parentModulePath, targetPath) {
     prelude = getImportGlobalsSrc();
 
     // We append our special setter and getter.
-    appendix = "module.exports.__set__ = " + __set__.toString() + "; ";
+    appendix = "\n";
+    appendix += "module.exports.__set__ = " + __set__.toString() + "; ";
     appendix += "module.exports.__get__ = " + __get__.toString() + "; ";
 
     // Check if the module uses the strict mode.


### PR DESCRIPTION
rewire cannnot load module that has comment on last line or without last line empty line or semicolon.

here gist is failed pattern
https://gist.github.com/suisho/5066182
