### PR TITLE
add the possibility to intercept require() calls

### DIFF
--- a/lib/__setRequiredModule__.js
+++ b/lib/__setRequiredModule__.js
@@ -1,0 +1,32 @@
+/**
+ * This function will be stringified and then injected into every rewired module.
+ * Then you can set private variables by calling myModule.__setRequiredModule__("module", mockModule);
+ *
+ * @param {!String|!Object} varName name of the variable to set
+ * @param {String} varValue new value
+ * @throws {TypeError}
+ * @throws {ReferenceError} When the variable is unknown
+ * @return {*}
+ */
+function __setRequiredModule__(key, mock_module) {
+    var requireOriginal = this.__requireOriginal__ || require;
+    var cache = this.__requireCache__ || {};
+
+    var path = requireOriginal("path");
+    var id = /^\/\./.test(key) ? path.resolve(__dirname, key) : key;
+    cache[id] = mock_module;
+
+    var requireMock = function (key) {
+        var id = /^\/\/./.test(key) ? path.resolve(__dirname, key) : key;
+        if ({}.hasOwnProperty.call(cache, id)) {
+            return cache[id];
+        }
+        return requireOriginal(key);
+    };
+
+    this.__requireCache__ = cache;
+    require = requireMock;
+    this.__requireOriginal__ = requireOriginal;
+};
+
+module.exports = __setRequiredModule__;

--- a/lib/__unsetRequiredModule__.js
+++ b/lib/__unsetRequiredModule__.js
@@ -1,0 +1,20 @@
+/**
+ * This function will be stringified and then injected into every rewired module.
+ * Then you can set private variables by calling myModule.__unsetRequiredModule__("module", mockModule);
+ *
+ * @param {!String|!Object} varName name of the variable to set
+ * @param {String} varValue new value
+ * @throws {TypeError}
+ * @throws {ReferenceError} When the variable is unknown
+ * @return {*}
+ */
+function __unsetRequiredModule__(key) {
+    var cache = this.__requireCache__;
+    if (cache) {
+        var path = require('path');
+        var id = /^\/\./.test(key) ? path.resolve(__dirname, key) : key;
+        delete cache[id];
+    }
+};
+
+module.exports = __unsetRequiredModule__;

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -2,6 +2,8 @@ var Module = require("module"),
     fs = require("fs"),
     __get__ = require("./__get__.js"),
     __set__ = require("./__set__.js"),
+    __setRequiredModule__ = require("./__setRequiredModule__.js"),
+    __unsetRequiredModule__ = require("./__unsetRequiredModule__.js"),
     getImportGlobalsSrc = require("./getImportGlobalsSrc.js"),
     detectStrictMode = require("./detectStrictMode.js"),
     moduleEnv = require("./moduleEnv.js");
@@ -40,6 +42,8 @@ function internalRewire(parentModulePath, targetPath) {
     appendix = "\n";
     appendix += "module.exports.__set__ = " + __set__.toString() + "; ";
     appendix += "module.exports.__get__ = " + __get__.toString() + "; ";
+    appendix += "module.exports.__setRequiredModule__ = " + __setRequiredModule__.toString() + "; ";
+    appendix += "module.exports.__unsetRequiredModule__ = " + __unsetRequiredModule__.toString() + "; ";
 
     // Check if the module uses the strict mode.
     // If so we must ensure that "use strict"; stays at the beginning of the module.

--- a/test/__setRequiredModule__.test.js
+++ b/test/__setRequiredModule__.test.js
@@ -1,0 +1,77 @@
+var expect = require("expect.js"),
+    fs = require("fs"),
+    path = require("path"),
+    __setRequiredModule__ = require("../lib/__setRequiredModule__.js"),
+    __unsetRequiredModule__ = require("../lib/__unsetRequiredModule__.js"),
+    vm = require("vm");
+
+describe("__setRequiredModule__/__unsetRequiredModule__", function () {
+    var requiringModuleFilename = path.join(__dirname, "testModules", "requiringModule.js");
+    var realRequiringModule = require(requiringModuleFilename);
+    var requiringModule;
+
+    var requireReal = function (key) {
+        if (/mockModule/.test(key)) {
+            throw new Error('no such module');
+        }
+        return realRequiringModule.getRequire()(key);
+    };
+
+    beforeEach(function () {
+        var src = fs.readFileSync(requiringModuleFilename);
+        src += "__setRequiredModule__ = " + __setRequiredModule__.toString() + ";";
+        src += "__unsetRequiredModule__ = " + __unsetRequiredModule__.toString() + ";";
+
+        requiringModule = {};
+        requiringModule.require = requireReal;
+        requiringModule.module = { exports: requiringModule };
+        requiringModule.exports = requiringModule.module.exports;
+        requiringModule.console = console;
+        requiringModule.__filename = requiringModuleFilename;
+        requiringModule.__dirname = path.dirname(requiringModuleFilename);
+        vm.runInNewContext(src, requiringModule);
+    });
+
+    describe('__setRequiredModule__', function () {
+        it("should set a mock installed module for future require() calls", function () {
+            expect(requiringModule.getInstalledModule).to.throwException();
+
+            var mockModule = {};
+            requiringModule.__setRequiredModule__("mockModule", mockModule);
+            expect(requiringModule.getInstalledModule()).to.be(mockModule);
+        });
+
+        it("should set a mock file module for future require() calls", function () {
+            expect(requiringModule.getFileModule).to.throwException();
+
+            var mockModule = {};
+            requiringModule.__setRequiredModule__("./mockModule.js", mockModule);
+            expect(requiringModule.getFileModule()).to.be(mockModule);
+        });
+    });
+
+    describe('__unsetRequiredModule__', function () {
+        it("should unset a mock installed module", function () {
+            expect(requiringModule.getInstalledModule).to.throwException();
+
+            var mockModule = {};
+            requiringModule.__setRequiredModule__("mockModule", mockModule);
+            expect(requiringModule.getInstalledModule()).to.be(mockModule);
+
+            requiringModule.__unsetRequiredModule__("mockModule");
+            expect(requiringModule.getInstalledModule).to.throwException();
+        });
+
+        it("should unset a mock file module", function () {
+            expect(requiringModule.getFileModule).to.throwException();
+
+            var mockModule = {};
+            requiringModule.__setRequiredModule__("./mockModule.js", mockModule);
+            expect(requiringModule.getFileModule()).to.be(mockModule);
+
+            requiringModule.__unsetRequiredModule__("./mockModule.js");
+            expect(requiringModule.getFileModule).to.throwException();
+        });
+    });
+});
+

--- a/test/testModules/requiringModule.js
+++ b/test/testModules/requiringModule.js
@@ -1,0 +1,12 @@
+
+exports.getRequire = function () {
+    return require;
+};
+
+exports.getInstalledModule = function () {
+    return require("mockModule");
+};
+
+exports.getFileModule = function () {
+    return require("./mockModule.js");
+};


### PR DESCRIPTION
These two functions make it possible to inject mock modules required after the host module is loaded.

If for instance a module has a method which requires another module in its logic, it is possible to inject the mock there:

```
// x.js:
exports.getModule = function () {
    return require("abc");
};
```

Even though the require call occurs after the module load, we can alter the results:

```
var theModule = require('./x.js');
theModule.__setRequiredModule__("abc", abc);
assert(theModule.getModule() === abc);
```
