### PR TITLE
Move `coffee-script` to "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "type": "git",
     "url": "git://github.com/jhnns/rewire.git"
   },
+  "dependencies": {
+    "coffee-script": "^1.8.0"
+  },
   "devDependencies": {
-    "coffee-script": "^1.8.0",
     "expect.js": "^0.3.1",
     "mocha": "^2.1.0"
   },


### PR DESCRIPTION
The `coffee-script` module is required for the rewire to run, so this is the proper location.

I ran into this while trying to use with Browserify, which will include `coffee-script` since it's `require`ed within the library even if it's never used. It may be a good idea to somehow separate out `coffee-script` so that it won't be bundled in unnecessarily.