### PR TITLE
Enable rewiring rewired modules

### DIFF
--- a/lib/getDefinePropertySrc.js
+++ b/lib/getDefinePropertySrc.js
@@ -18,7 +18,8 @@ function getDefinePropertySrc() {
             value +
             "', {enumerable: false, value: " +
             srcs[value] +
-            "}); ";
+            ", "+
+            "writable: true}); ";
     }, "");
 
     return src;

--- a/test/testModules/sharedTestCases.js
+++ b/test/testModules/sharedTestCases.js
@@ -66,16 +66,17 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         expect(rewire("./moduleB.js").__with__.toString()).to.be(__with__Src);
     });
 
-    it("should provide __set__ as a non-enumerable property", function () {
-        expect(Object.keys(rewire("./moduleA.js")).indexOf("__set__")).to.be(-1)
-    });
 
-    it("should provide __get__ as a non-enumerable property", function () {
-        expect(Object.keys(rewire("./moduleA.js")).indexOf("__get__")).to.be(-1)
-    });
+    ["__get__", "__set__", "__with__"].forEach(function(funcName) {
+        it("should provide " + funcName + " as a non-enumerable property", function () {
+            expect(Object.keys(rewire("./moduleA.js")).indexOf(funcName)).to.be(-1)
+        });
 
-    it("should provide __with__ as a non-enumerable property", function () {
-        expect(Object.keys(rewire("./moduleA.js")).indexOf("__with__")).to.be(-1)
+        it("should provide " + funcName + " as a writable property", function () {
+            var obj = rewire("./moduleA.js");
+            var desc = Object.getOwnPropertyDescriptor(obj, funcName);
+            expect(desc.writable).to.be(true);
+        });
     });
 
     it("should not influence other modules", function () {


### PR DESCRIPTION
babel-plugin-rewire, rewireify, and rewire-global all hook require, injecting the functions into every module. 

When we use [getDefinePropertySrc](https://github.com/jhnns/rewire/blob/master/lib/getDefinePropertySrc.js) we run into problems on modules that pass through their dependencies unchanged. See this failing test on rewire-global: https://github.com/TheSavior/rewire-global/pull/13/files

The error we get is:
```
TypeError: Cannot redefine property: __get__
      at Function.defineProperty (native)
      at test/fixtures/keys-pass-through.js:7:8
      at Object.<anonymous> (test/fixtures/keys-pass-through.js:101:9)
      at Context.<anonymous> (test/tests/tests.js:63:5)
```

Before starting to use the upstream modules from rewire in rewireify and rewire-global, we got around this by setting the properties to writable: https://github.com/i-like-robots/rewireify/blob/master/lib/index.js#L37

Rewire [does not set them to writable](https://github.com/jhnns/rewire/blob/master/lib/getDefinePropertySrc.js#L17).
