### PR TITLE
Should not try to attach to modules that export primitives

### DIFF
--- a/lib/getDefinePropertySrc.js
+++ b/lib/getDefinePropertySrc.js
@@ -11,9 +11,10 @@ var srcs = {
 };
 
 function getDefinePropertySrc() {
-    var src;
+    var src = "if (typeof(module.exports) === 'function' || \n" +
+            "(typeof(module.exports) === 'object' && module.exports !== null && Object.isExtensible(module.exports))) {\n";
 
-    src = Object.keys(srcs).reduce(function forEachSrc(preValue, value) {
+    src += Object.keys(srcs).reduce(function forEachSrc(preValue, value) {
         return preValue += "Object.defineProperty(module.exports, '" +
             value +
             "', {enumerable: false, value: " +
@@ -21,6 +22,8 @@ function getDefinePropertySrc() {
             ", "+
             "writable: true}); ";
     }, "");
+
+    src += "\n}";
 
     return src;
 }

--- a/testLib/boolean.js
+++ b/testLib/boolean.js
@@ -1,0 +1,1 @@
+module.exports = true;

--- a/testLib/null.js
+++ b/testLib/null.js
@@ -1,0 +1,1 @@
+module.exports = null;

--- a/testLib/sealedObject.js
+++ b/testLib/sealedObject.js
@@ -1,0 +1,4 @@
+var obj = {};
+Object.seal(obj);
+
+module.exports = obj;

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -220,6 +220,24 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         expect(rewired.__get__("someVar")).to.be("hello");
     });
 
+    it("should not be a problem to have a module that exports a boolean", function() {
+        expect(function() {
+            var rewired = rewire("./boolean.js");
+        }).to.not.throwException();
+    });
+
+    it("should not be a problem to have a module that exports null", function() {
+        expect(function() {
+            var rewired = rewire("./null.js");
+        }).to.not.throwException();
+    });
+
+    it("should not be a problem to have a module that exports a sealed object", function() {
+        expect(function() {
+            var rewired = rewire("./sealedObject.js");
+        }).to.not.throwException();
+    });
+
     it("should not influence the original require if nothing has been required within the rewired module", function () {
         rewire("./emptyModule.js"); // nothing happens here because emptyModule doesn't require anything
         expect(require("./moduleA.js").__set__).to.be(undefined); // if restoring the original node require didn't worked, the module would have a setter


### PR DESCRIPTION
When people use rewire, they wouldn't typically try to explicitly rewire modules that export primitives. 

However, since reweireify, rewire-global, and babel-plugin-rewire all get injected to every module, this needs to not blow up on objects that can't be attached to.

rewireify and rewire-global use `Object.isExtensible` instead of the type check. The behavior of `Object.isExtensible` change from es5 to es6. In ES5, it would throw if given something that was not an object. in ES6, it returns false. rewireify and rewire-global all run in the browser and all modern browsers have the es6 version of the functionality. Node 0.12 has the es5 functionality, so we need to use the type check instead.

I added a test to make sure that it doesn't blow up on modules that return sealed objects. `Object.defineProperty` will run and not throw, but won't actually modify the object. 