### PR TITLE
Pulling out the module wrapper definition into a new file

### DIFF
--- a/lib/moduleWrapperSrc.js
+++ b/lib/moduleWrapperSrc.js
@@ -1,0 +1,22 @@
+var getImportGlobalsSrc = require("./getImportGlobalsSrc.js"),
+    getDefinePropertySrc = require("./getDefinePropertySrc.js");
+
+// We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
+var prelude = getImportGlobalsSrc();
+
+// Wrap module src inside IIFE so that function declarations do not clash with global variables
+// @see https://github.com/jhnns/rewire/issues/56
+prelude += "(function () { ";
+
+// We append our special setter and getter.
+var appendix = "\n" + getDefinePropertySrc();
+
+// End of IIFE
+appendix += "})();";
+
+var ModuleWrapper = {
+  prelude: prelude,
+  appendix: appendix
+};
+
+module.exports = ModuleWrapper;

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -1,7 +1,6 @@
 var Module = require("module"),
     fs = require("fs"),
-    getImportGlobalsSrc = require("./getImportGlobalsSrc.js"),
-    getDefinePropertySrc = require("./getDefinePropertySrc.js"),
+    moduleWrapperSrc = require("./moduleWrapperSrc.js"),
     detectStrictMode = require("./detectStrictMode.js"),
     moduleEnv = require("./moduleEnv.js");
 
@@ -33,18 +32,8 @@ function internalRewire(parentModulePath, targetPath) {
     // Create testModule as it would be created by require()
     targetModule = new Module(targetPath, parentModulePath);
 
-    // We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
-    prelude = getImportGlobalsSrc();
-
-    // Wrap module src inside IIFE so that function declarations do not clash with global variables
-    // @see https://github.com/jhnns/rewire/issues/56
-    prelude += "(function () { ";
-
-    // We append our special setter and getter.
-    appendix = "\n" + getDefinePropertySrc();
-
-    // End of IIFE
-    appendix += "})();";
+    prelude = moduleWrapperSrc.prelude;
+    appendix = moduleWrapperSrc.appendix;
 
     // Check if the module uses the strict mode.
     // If so we must ensure that "use strict"; stays at the beginning of the module.


### PR DESCRIPTION
This will let rewire, rewire-global, and rewireify use the same module without custom work. 
