### PR TITLE
Only add .coffee to extensions if it was present before

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -47,12 +47,17 @@ function requireProxy(path) {
 }
 
 function registerExtensions() {
-    originalExtensions.coffee = require.extensions[".coffee"];
+    var originalCoffeeExtension = require.extensions[".coffee"];
+    if (originalCoffeeExtension) {
+        originalExtensions.coffee = originalCoffeeExtension;
+    }
     require.extensions[".coffee"] = coffeeExtension;
 }
 
 function restoreExtensions() {
-    require.extensions[".coffee"] = originalExtensions.coffee;
+    if ("coffee" in originalExtensions) {
+        require.extensions[".coffee"] = originalExtensions.coffee;
+    }
 }
 
 function coffeeExtension(module, filename) {


### PR DESCRIPTION
The `restoreExtensions()` function currently results in a `'.coffee': undefined` member in `require.extensions`.

On Node 5, if I have a script like the one below (where `index.js` is empty), I get the output below:
```js
var rewire = require('rewire');
console.log(require.extensions);
rewire('./index.js');
console.log(require.extensions);
```

```
{ '.js': [Function], '.json': [Function], '.node': [Function] }
{ '.js': [Function],
  '.json': [Function],
  '.node': [Function],
  '.coffee': undefined }
```

So, no `.coffee` before, and `'.coffee': undefined` after.

The changes in this branch make it so `require.extensions` is not modified if `.coffee` is not present in the original.