### PR TITLE
Fix 101

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rewire
 [![](https://img.shields.io/npm/v/rewire.svg)](https://www.npmjs.com/package/rewire)
 [![](https://img.shields.io/npm/dm/rewire.svg)](https://www.npmjs.com/package/rewire)
 [![Dependency Status](https://david-dm.org/jhnns/rewire.svg)](https://david-dm.org/jhnns/rewire)
-[![Build Status](https://travis-ci.org/jhnns/rewire.svg?branch=master)](https://travis-ci.org//jhnns/rewire)
+[![Build Status](https://travis-ci.org/jhnns/rewire.svg?branch=master)](https://travis-ci.org/jhnns/rewire)
 [![Coverage Status](https://img.shields.io/coveralls/jhnns/rewire.svg)](https://coveralls.io/r/jhnns/rewire?branch=master)
 
 rewire adds a special setter and getter to modules so you can modify their behaviour for better unit testing. You may

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rewire
 [![](https://img.shields.io/npm/v/rewire.svg)](https://www.npmjs.com/package/rewire)
 [![](https://img.shields.io/npm/dm/rewire.svg)](https://www.npmjs.com/package/rewire)
 [![Dependency Status](https://david-dm.org/jhnns/rewire.svg)](https://david-dm.org/jhnns/rewire)
-[![Build Status](https://travis-ci.org/jhnns/rewire.svg?branch=master)](https://travis-ci.org/rewire/jhnns)
+[![Build Status](https://travis-ci.org/jhnns/rewire.svg?branch=master)](https://travis-ci.org//jhnns/rewire)
 [![Coverage Status](https://img.shields.io/coveralls/jhnns/rewire.svg)](https://coveralls.io/r/jhnns/rewire?branch=master)
 
 rewire adds a special setter and getter to modules so you can modify their behaviour for better unit testing. You may
@@ -140,7 +140,7 @@ Limitations
 -----------
 
 **Using `const`**<br>
-It's not possible to rewire `const` (see [#79](https://github.com/jhnns/rewire/issues/79)). This can probably be solved with [proxies](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Proxy) someday but requires further research. 
+It's not possible to rewire `const` (see [#79](https://github.com/jhnns/rewire/issues/79)). This can probably be solved with [proxies](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Proxy) someday but requires further research.
 
 **Transpilers**<br>
 Some transpilers, like babel, rename variables in order to emulate certain language features. Rewire will not work in these cases (see [#62](https://github.com/jhnns/rewire/issues/62)). A possible solution might be switching to [babel-plugin-rewire](https://github.com/speedskater/babel-plugin-rewire).

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,11 @@ var rewireModule = require("./rewire.js");
  * call myModule.__set__(name, value) and myModule.__get__(name) to manipulate private variables.
  *
  * @param {!String} filename Path to the module that shall be rewired. Use it exactly like require().
+ * @param {Object} options Options.
  * @return {*} the rewired module
  */
-function rewire(filename) {
-    return rewireModule(module.parent, filename);
+function rewire(filename, options) {
+    return rewireModule(module.parent, filename, options);
 }
 
 module.exports = rewire;

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -8,7 +8,7 @@ var Module = require("module"),
 /**
  * Does actual rewiring the module. For further documentation @see index.js
  */
-function internalRewire(parentModulePath, targetPath) {
+function internalRewire(parentModulePath, targetPath, options) {
     var targetModule,
         prelude,
         appendix,
@@ -18,6 +18,8 @@ function internalRewire(parentModulePath, targetPath) {
     if (typeof targetPath !== "string") {
         throw new TypeError("Filename must be a string");
     }
+
+    options = options || {}
 
     // Resolve full filename relative to the parent module
     targetPath = Module._resolveFilename(targetPath, parentModulePath);
@@ -34,7 +36,7 @@ function internalRewire(parentModulePath, targetPath) {
     targetModule = new Module(targetPath, parentModulePath);
 
     // We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
-    prelude = getImportGlobalsSrc();
+    prelude = getImportGlobalsSrc(options.ignore);
 
     // Wrap module src inside IIFE so that function declarations do not clash with global variables
     // @see https://github.com/jhnns/rewire/issues/56


### PR DESCRIPTION
There is an ability to ignore globals in `getImportGlobalsSrc` If rewired module can accept options and pass `options.ignore` to getImportGlobalsSrc then #101 can be fixed.

Please let me know if you need me to update readme and add test case for this issues