### PR TITLE
Enable mocking of const

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.12"
   - "4"
   - "5"
+  - "6"
 
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -179,14 +179,9 @@ Please be aware that you can't rewire `eval()` or the global object itself.
 API
 ---
 
-### rewire(filename: String, [options]): rewiredModule
+### rewire(filename: String): rewiredModule
 
 Returns a rewired version of the module found at `filename`. Use `rewire()` exactly like `require()`.
-
-#### Options
-| Property | Default | Description |
-|----------|---------|-------------|
-| convertConst | false | Set to true to convert all `const` variables of the required module to `let`. This way you can mock const variables. **Caution**: Setting this to true can lead to inaccurate tests.
 
 ### rewiredModule.&#95;&#95;set&#95;&#95;(name: String, value: *): Function
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ myModule.__with__({
 Limitations
 -----------
 
-**Using `const`**<br>
-It's not possible to rewire `const` (see [#79](https://github.com/jhnns/rewire/issues/79)). This can probably be solved with [proxies](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Proxy) someday but requires further research. 
-
 **Transpilers**<br>
 Some transpilers, like babel, rename variables in order to emulate certain language features. Rewire will not work in these cases (see [#62](https://github.com/jhnns/rewire/issues/62)). A possible solution might be switching to [babel-plugin-rewire](https://github.com/speedskater/babel-plugin-rewire).
 
@@ -182,9 +179,14 @@ Please be aware that you can't rewire `eval()` or the global object itself.
 API
 ---
 
-### rewire(filename: String): rewiredModule
+### rewire(filename: String, [options]): rewiredModule
 
 Returns a rewired version of the module found at `filename`. Use `rewire()` exactly like `require()`.
+
+#### Options
+| Property | Default | Description |
+|----------|---------|-------------|
+| convertConst | false | Set to true to convert all `const` variables of the required module to `let`. This way you can mock const variables. **Caution**: Setting this to true can lead to inaccurate tests.
 
 ### rewiredModule.&#95;&#95;set&#95;&#95;(name: String, value: *): Function
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@ var rewireModule = require("./rewire.js");
  * @param {!String} filename Path to the module that shall be rewired. Use it exactly like require().
  * @return {*} the rewired module
  */
-function rewire(filename, opts) {
-    return rewireModule(module.parent, filename, opts);
+function rewire(filename) {
+    return rewireModule(module.parent, filename);
 }
 
 module.exports = rewire;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@ var rewireModule = require("./rewire.js");
  * @param {!String} filename Path to the module that shall be rewired. Use it exactly like require().
  * @return {*} the rewired module
  */
-function rewire(filename) {
-    return rewireModule(module.parent, filename);
+function rewire(filename, opts) {
+    return rewireModule(module.parent, filename, opts);
 }
 
 module.exports = rewire;

--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -12,7 +12,7 @@ var moduleWrapper0 = Module.wrapper[0],
     nodeRequire,
     currentModule;
 
-function load(targetModule, isTransform) {
+function load(targetModule) {
     nodeRequire = targetModule.require;
     targetModule.require = requireProxy;
     currentModule = targetModule;

--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -2,6 +2,7 @@
 
 var Module = require("module"),
     fs = require("fs"),
+    babelCore = require("babel-core"),
     coffee;
 
     // caching original wrapper
@@ -11,15 +12,31 @@ var moduleWrapper0 = Module.wrapper[0],
     nodeRequire,
     currentModule;
 
-function load(targetModule) {
+function load(targetModule, isTransform) {
     nodeRequire = targetModule.require;
     targetModule.require = requireProxy;
     currentModule = targetModule;
 
     registerExtensions();
+
     targetModule.load(targetModule.id);
 
     // This is only necessary if nothing has been required within the module
+    reset();
+}
+
+function compile(targetModule, src, filename) {
+    nodeRequire = targetModule.require;
+    targetModule.require = requireProxy;
+    targetModule.filename = filename;
+    currentModule = targetModule;
+
+    var convertedSrc = babelCore.transform(stripBOM(src), {
+        plugins: ["transform-es2015-constants"]
+    });
+
+    targetModule._compile(convertedSrc.code, filename);
+
     reset();
 }
 
@@ -91,4 +108,5 @@ try {
 }
 
 exports.load = load;
+exports.compile = compile;
 exports.inject = inject;

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -9,15 +9,11 @@ var Module = require("module"),
 /**
  * Does actual rewiring the module. For further documentation @see index.js
  */
-function internalRewire(parentModulePath, targetPath, opts) {
+function internalRewire(parentModulePath, targetPath) {
     var targetModule,
         prelude,
         appendix,
-        src,
-        isTransform;
-
-    opts = typeof opts === "object" ? opts : {};
-    isTransform = !!opts.convertConst;
+        src;
 
     // Checking params
     if (typeof targetPath !== "string") {
@@ -60,11 +56,12 @@ function internalRewire(parentModulePath, targetPath, opts) {
 
     moduleEnv.inject(prelude, appendix);
 
-    if(isTransform) {
-        moduleEnv.compile(targetModule, src, targetPath);
-    } else {
+    if (targetPath.match(/\.coffee$/)) {
         moduleEnv.load(targetModule);
+    } else {
+        moduleEnv.compile(targetModule, src, targetPath);
     }
+
 
     return targetModule.exports;
 }

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -1,5 +1,6 @@
 var Module = require("module"),
     fs = require("fs"),
+    path = require("path"),
     getImportGlobalsSrc = require("./getImportGlobalsSrc.js"),
     getDefinePropertySrc = require("./getDefinePropertySrc.js"),
     detectStrictMode = require("./detectStrictMode.js"),
@@ -8,11 +9,15 @@ var Module = require("module"),
 /**
  * Does actual rewiring the module. For further documentation @see index.js
  */
-function internalRewire(parentModulePath, targetPath) {
+function internalRewire(parentModulePath, targetPath, opts) {
     var targetModule,
         prelude,
         appendix,
-        src;
+        src,
+        isTransform;
+
+    opts = typeof opts === "object" ? opts : {};
+    isTransform = !!opts.convertConst;
 
     // Checking params
     if (typeof targetPath !== "string") {
@@ -54,7 +59,12 @@ function internalRewire(parentModulePath, targetPath) {
     }
 
     moduleEnv.inject(prelude, appendix);
-    moduleEnv.load(targetModule);
+
+    if(isTransform) {
+        moduleEnv.compile(targetModule, src, targetPath);
+    } else {
+        moduleEnv.load(targetModule);
+    }
 
     return targetModule.exports;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,668 @@
+{
+  "name": "rewire",
+  "version": "2.5.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-constants": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-constants/-/babel-plugin-transform-es2015-constants-6.1.4.tgz",
+      "integrity": "sha1-5LjHj7SKuYsBB/Mp+rYEDnnDWjM=",
+      "requires": {
+        "babel-runtime": "5.8.38"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "requires": {
+            "core-js": "1.2.7"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.2",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "coffee": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/coffee/-/coffee-4.1.0.tgz",
+      "integrity": "sha512-u+FW/4zAddbyKhyMz1A/2pbxmBTbGLdx6U3rzl7m6X1qUkrL6CKvt9b1oEGpmMVQKljWSqivPMf9BNQObmZhaQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "coffeescript": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.0.1.tgz",
+      "integrity": "sha512-mrgXUOwRocrvSRwIi/2tAesQOJz2KxSyMNMlLSVhnJk/eZHKinYSJGcgUYZkzmSQZtpb3UhGJeZv0AAUeh7yyQ==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+    },
+    "core-js": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "test": "mocha -R spec --check-leaks",
+    "test": "mocha -R spec --check-leaks --globals __core-js_shared__",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha"
+  },
+  "dependencies": {
+    "babel-core": "~6.26.0",
+    "babel-plugin-transform-es2015-constants": "~6.1.4"
   }
 }

--- a/testLib/ES2015Module.js
+++ b/testLib/ES2015Module.js
@@ -1,0 +1,14 @@
+
+const someOtherModule = require("./someOtherModule");
+const language = "nl";
+
+module.exports.getLang = () => {
+    return language;
+}
+
+exports.getOtherModuleName = () => {
+    return someOtherModule.name;
+}
+
+exports.filename = __filename;
+exports.dirname = __dirname;

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -382,8 +382,8 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         })(function() {
             expect(ES2015Module.getLang()).to.equal("en");
             expect(ES2015Module.getOtherModuleName()).to.equal("somOtherModule");
-        })
-    })
+        });
+    });
 
     it("Should be possible to mock a const required variable using __with__ syntax", function() {
         var ES2015Module = rewire("./ES2015Module", {
@@ -397,7 +397,21 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         })(function() {
             expect(ES2015Module.getLang()).to.equal("nl");
             expect(ES2015Module.getOtherModuleName()).to.equal("mocked");
-        })
+        });
+    });
+
+    it("Should be possible to mock a set a const variable using __set__ syntax", function() {
+        var ES2015Module = rewire("./ES2015Module", {
+            convertConst: true
+        });
+
+        ES2015Module.__set__("language", "de");
+
+        expect(ES2015Module.getLang()).to.equal("de");
+
+        ES2015Module.__set__("language", "nl");
+
+        expect(ES2015Module.getLang()).to.equal("nl");
     })
 
 });

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -372,4 +372,32 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         revert();
     });
 
+    it("Should be possible to mock a const variable using __with__ syntax", function() {
+        var ES2015Module = rewire("./ES2015Module", {
+            convertConst: true
+        });
+
+        ES2015Module.__with__({
+            language: "en"
+        })(function() {
+            expect(ES2015Module.getLang()).to.equal("en");
+            expect(ES2015Module.getOtherModuleName()).to.equal("somOtherModule");
+        })
+    })
+
+    it("Should be possible to mock a const required variable using __with__ syntax", function() {
+        var ES2015Module = rewire("./ES2015Module", {
+            convertConst: true
+        });
+
+        ES2015Module.__with__({
+            someOtherModule: {
+                name: "mocked"
+            }
+        })(function() {
+            expect(ES2015Module.getLang()).to.equal("nl");
+            expect(ES2015Module.getOtherModuleName()).to.equal("mocked");
+        })
+    })
+
 });

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -417,6 +417,6 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
     it("Should have correct __filename and __dirname when mocked using convertConst", function() {
         expect(rewire("./ES2015Module", { convertConst: true }).filename).to.equal(require("./ES2015Module").filename);
         expect(rewire("./ES2015Module", { convertConst: true }).dirname).to.equal(require("./ES2015Module").dirname);
-    })
+    });
 
 });

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -414,4 +414,9 @@ describe("rewire " + (typeof testEnv === "undefined"? "(node)": "(" + testEnv + 
         expect(ES2015Module.getLang()).to.equal("nl");
     })
 
+    it("Should have correct __filename and __dirname when mocked using convertConst", function() {
+        expect(rewire("./ES2015Module", { convertConst: true }).filename).to.equal(require("./ES2015Module").filename);
+        expect(rewire("./ES2015Module", { convertConst: true }).dirname).to.equal(require("./ES2015Module").dirname);
+    })
+
 });

--- a/testLib/someOtherModule.js
+++ b/testLib/someOtherModule.js
@@ -4,3 +4,4 @@ __filename = "/test/testModules/someOtherModule.js";
 
 exports.fs = {};
 exports.filename = __filename;
+exports.name = "somOtherModule";


### PR DESCRIPTION
This PR enables the mocking of const variables.
It uses Babel to parse the code and transform const to let variables.

It can solve the following issues: #95, #79 