### PR TITLE
use 'coffeescript' package

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -89,6 +89,10 @@ function jsExtension(module, filename) {
 }
 
 function coffeeExtension(module, filename) {
+    if (!coffee) {
+        throw new Error("please add 'coffeescript' to your devDependencies");
+    }
+
     var content = stripBOM(fs.readFileSync(filename, "utf8"));
 
     restoreExtensions();
@@ -113,9 +117,14 @@ function stripBOM(content) {
 }
 
 try {
-    coffee = require("coffee-script");
+    coffee = require("coffeescript");
 } catch (err) {
-    // We are not able to provide coffee-script support, but that's ok as long as the user doesn't want it.
+    try {
+        // Trying to load deprecated package
+        coffee = require("coffee-script");
+    } catch (err) {
+        // We are not able to provide coffee-script support, but that's ok as long as the user doesn't want it.
+    }
 }
 
 exports.load = load;

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,10 +238,10 @@
         }
       }
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+    "coffeescript": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.1.1.tgz",
+      "integrity": "sha512-Tl2z6/rNMqJ2LqWlVxLKwLF9FniwJpweonfSLCwhX8NFCEsGBcFIErtfKd8+t4XHDSYRshj9FXxPX53BT3lC9w==",
       "dev": true
     },
     "commander": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git://github.com/jhnns/rewire.git"
   },
   "devDependencies": {
-    "coffee-script": "^1.8.0",
+    "coffeescript": "^2.1.1",
     "expect.js": "^0.3.1",
     "mocha": "^4.0.1"
   },


### PR DESCRIPTION
The `coffee-script` package is old and deprecated (didn't update for a while, doesn't allow new JavaScript syntax). The new package is `coffeescript`.

This pull request:
1. Tries loading `coffeescript` first and then `coffee-script`.
2. Gives a proper message when trying to use coffeescript extension without coffeescript loaded (was previously `TypeError: Cannot read property 'compile' of undefined`).
3. Changed the dev dependency.

I feel like `coffeescript` shouldn't be in `devDependencies` but in `peerDependencies` or something, but couldn't get it to work. Currently it simply cannot really fail loading coffeescript since it's a dependency.

Closes #126 