### PR TITLE
Add support for object spread/rest operator.

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -76,7 +76,10 @@ function jsExtension(module, filename) {
 
     module._compile = function (content, filename) {
         content = babelCore.transform(content, {
-            plugins: [require.resolve("babel-plugin-transform-es2015-block-scoping")],
+            plugins: [
+                require.resolve("babel-plugin-transform-es2015-block-scoping"),
+                require.resolve("babel-plugin-transform-object-rest-spread")
+            ],
             retainLines: true,
             filename: filename,
             babelrc: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,11 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
@@ -115,6 +120,15 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-register": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "babel-core": "^6.26.0",
-    "babel-plugin-transform-es2015-block-scoping": "^6.26.0"
+    "babel-plugin-transform-es2015-block-scoping": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0"
   }
 }

--- a/testLib/objectRestOperator.js
+++ b/testLib/objectRestOperator.js
@@ -1,0 +1,2 @@
+let { ...a } = {};
+module.exports = a;

--- a/testLib/objectSpreadOperator.js
+++ b/testLib/objectSpreadOperator.js
@@ -1,0 +1,1 @@
+module.exports = { ...{} };

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -238,6 +238,18 @@ module.exports = function () {
         }).to.not.throwException();
     });
 
+    it("should not be a problem to have a module that uses object spread operator", function() {
+        expect(function() {
+            var rewired = rewire("./objectSpreadOperator.js");
+        }).to.not.throwException();
+    });
+
+    it("should not be a problem to have a module that uses object rest operator", function() {
+        expect(function() {
+            var rewired = rewire("./objectRestOperator.js");
+        }).to.not.throwException();
+    });
+
     it("should not influence the original require if nothing has been required within the rewired module", function () {
         rewire("./emptyModule.js"); // nothing happens here because emptyModule doesn't require anything
         expect(require("./moduleA.js").__set__).to.be(undefined); // if restoring the original node require didn't worked, the module would have a setter


### PR DESCRIPTION
Before this commit, using rewire on a module that had object spread/rest
operator in it would throw an exception. Now it doesn't.