### PR TITLE
move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "coffeescript": "^2.1.1",
+    "eslint": "^4.19.1",
     "expect.js": "^0.3.1",
     "mocha": "^4.0.1"
   },
@@ -38,8 +39,5 @@
   "scripts": {
     "test": "mocha -R spec",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha"
-  },
-  "dependencies": {
-    "eslint": "^4.19.1"
   }
 }


### PR DESCRIPTION
Having eslint as a dependencies causes my project to pull eslint to the project's `node_modules`, which overrides my globally installed eslint.

Since eslint is only required for developing rewire and is not required for rewire to function, it should be moved to devDependencies.

Thanks!