### PR TITLE
Update Node versions used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
+  - "node"
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "9"
+  - "10"
 
 script:
   - npm test


### PR DESCRIPTION
We drop 9 in favour of 10, since 10 is the LTS-version.

Using Node 10 in our tests is essential: for example #167 was unnoticed for a long time, since it only happened on Node 10, not on Node 9.