### PR TITLE
Fixed import errors on modules with shebang declarations

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -43,6 +43,8 @@ var moduleWrapper0 = Module.wrapper[0],
     // errors anyway, it's probably still a reasonable trade-off.
     // Test the regular expresssion at https://regex101.com/r/dvnZPv/2 and also check out testLib/constModule.js.
     matchConst = /(^|\s|\}|;)const(\/\*|\s|{)/gm,
+    // Required for importing modules with shebang declarations, since NodeJS 12.16.0
+    shebang = /^(#!).+/,
     nodeRequire,
     currentModule;
 
@@ -123,7 +125,9 @@ function jsExtension(module, filename) {
 
         _compile.call(
             module,
-            content.replace(matchConst, "$1let  $2"), // replace const with let, while maintaining the column width
+            content
+                .replace(shebang, '') // Remove shebang declarations
+                .replace(matchConst, "$1let  $2"), // replace const with let, while maintaining the column width
             filename
         );
     };

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -408,4 +408,9 @@ module.exports = function () {
         }).to.throwException(/^Assignment to constant variable at .+?wrongConstModule\.js:4:1$/);
     });
 
+    it("should be possible to rewire shebang modules", function () {
+        expect(function () {
+            rewire("./shebangModule");
+        }).to.not.throwError();
+    });
 };

--- a/testLib/shebangModule.js
+++ b/testLib/shebangModule.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+function shebangs() {
+    return true;
+}
+
+module.exports.shebangs = shebangs;


### PR DESCRIPTION
Fixes #178 

I feel like the issue should really be fixed in NodeJS, but this PR provides a workaround for the time being.

I've isolated the tests and the fix into two different commits, so that the fix commit could be reverted at a later date easily, should NodeJS provides a fix in the future.

This fixes the issue by removing the shebang declaration during the import via a regex that scans the first line of the module source. I believe this is a safe workaround because during a test environment, we don't need shebang declarations.

I've ran `npm test` to ensure all other tests passed.

Additionally I've tested my changes locally on https://github.com/apache/cordova-android who is exhibiting this issue on NodeJS 12.16.0+

Do note that this is not an issue on NodeJS 12.15 or earlier.