### PR TITLE
Add an option to intercept and rewire nested requires

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@ var rewireModule = require("./rewire.js");
  * @param {!String} filename Path to the module that shall be rewired. Use it exactly like require().
  * @return {*} the rewired module
  */
-function rewire(filename) {
-    return rewireModule(module.parent, filename);
+function rewire(filename, rewireNestedRequires) {
+    return rewireModule(module.parent, filename, rewireNestedRequires);
 }
 
 module.exports = rewire;

--- a/lib/rewire.js
+++ b/lib/rewire.js
@@ -8,7 +8,7 @@ var Module = require("module"),
 /**
  * Does actual rewiring the module. For further documentation @see index.js
  */
-function internalRewire(parentModulePath, targetPath) {
+function internalRewire(parentModulePath, targetPath, rewireNestedRequires) {
     var targetModule,
         prelude,
         appendix,
@@ -27,6 +27,22 @@ function internalRewire(parentModulePath, targetPath) {
 
     // We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
     prelude = getImportGlobalsSrc();
+
+    // If asked, intercept require calls when evaluating the rewired module to rewire those inner requires
+    if (rewireNestedRequires) {
+        targetModule.__rewire__ = internalRewire;
+
+        prelude += `
+            const __oldRequire = require;
+            var require = function(path) {
+                if (module.__rewire__) {
+                    return module.__rewire__(module.parent, path);
+                } else {
+                    return __oldRequire(path);
+                }
+            };
+        `
+    }
 
     // Wrap module src inside IIFE so that function declarations do not clash with global variables
     // @see https://github.com/jhnns/rewire/issues/56

--- a/testLib/sharedTestCases.js
+++ b/testLib/sharedTestCases.js
@@ -408,4 +408,17 @@ module.exports = function () {
         }).to.throwException(/^Assignment to constant variable at .+?wrongConstModule\.js:4:1$/);
     });
 
+    it("should not rewire nested requires by default", function () {
+        const a = rewire('./moduleA')
+        const b = rewire('./moduleB')
+
+        expect(a.someOtherModule.date).to.equal(b.someOtherModule.date)
+    })
+
+    it("should rewire nested requires by default", function () {
+        const a = rewire('./moduleA', true)
+        const b = rewire('./moduleB', true)
+
+        expect(a.someOtherModule.date).not.to.equal(b.someOtherModule.date)
+    })
 };

--- a/testLib/someOtherModule.js
+++ b/testLib/someOtherModule.js
@@ -5,3 +5,4 @@ __filename = "/test/testModules/someOtherModule.js";
 exports.fs = {};
 exports.filename = __filename;
 exports.name = "somOtherModule";
+exports.date = new Date();


### PR DESCRIPTION
Follow up to #73

This adds support for rewire-ing the *inner* modules required by a rewire'd module. This is really useful if you have transitive dependencies you also want to mock, or if you are using rewire as a userland require implementation, to have rewire use it's own userland implementation for nested requires as opposed to just the outer one. 