### PR TITLE
Fix issue where rewire can hold reference to its own extension

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -7,7 +7,10 @@ var Module = require("module"),
 
 var moduleWrapper0 = Module.wrapper[0],
     moduleWrapper1 = Module.wrapper[1],
-    originalExtensions = {},
+    originalExtensions = {
+        js: [],
+        ts: [],
+    },
     linter = new eslint.Linter(),
     eslintOptions = {
         env: {
@@ -85,18 +88,18 @@ function registerExtensions() {
     var originalTsExtension = require.extensions[".ts"];
 
     if (originalJsExtension) {
-        originalExtensions.js = originalJsExtension;
+        originalExtensions.js.push(originalJsExtension);
     }
     if (originalTsExtension) {
-        originalExtensions.ts = originalTsExtension;
+        originalExtensions.ts.push(originalTsExtension);
     }
     require.extensions[".js"] = jsExtension;
     require.extensions[".ts"] = tsExtension;
 }
 
 function restoreExtensions() {
-    if ("js" in originalExtensions) {
-        require.extensions[".js"] = originalExtensions.js;
+    if (originalExtensions.js.length) {
+        require.extensions[".js"] = originalExtensions.js.pop();
     }
     if ("ts" in originalExtensions) {
         require.extensions[".ts"] = originalExtensions.ts;
@@ -109,6 +112,7 @@ function isNoConstAssignMessage(message) {
 
 function jsExtension(module, filename) {
     var _compile = module._compile;
+    var original = originalExtensions.js[originalExtensions.js.length - 1];
 
     module._compile = function (content, filename) {
         var noConstAssignMessage = linter.verify(content, eslintOptions).find(isNoConstAssignMessage);
@@ -131,11 +135,12 @@ function jsExtension(module, filename) {
     };
 
     restoreExtensions();
-    originalExtensions.js(module, filename);
+    original(module, filename);
 }
 
 function tsExtension(module, filename) {
     var _compile = module._compile;
+    var original = originalExtensions.ts[originalExtensions.ts.length - 1];
 
     module._compile = function rewireCompile(content, filename) {
         var noConstAssignMessage = linter.verify(content, eslintOptions).find(isNoConstAssignMessage);
@@ -157,7 +162,7 @@ function tsExtension(module, filename) {
     };
 
     restoreExtensions();
-    originalExtensions.ts(module, filename);
+    original(module, filename);
 }
 
 exports.load = load;


### PR DESCRIPTION
This attempts to fix a slightly strange issue I had when using `rewire` with `ts-node`. For some reason (I think because the `ts-node` loader is doing some magic with the js loader too) if I include rewire several times in my files it ends up holding a reference to itself as the `originalExtension` instead of the true original.

Error:

```
RangeError: Maximum call stack size exceeded
    at restoreExtensions (node_modules\rewire\lib\moduleEnv.js:99:27)
    at Object.jsExtension [as js] (node_modules\rewire\lib\moduleEnv.js:135:5)
    ...
```

This patch fixes the problem for me locally, but I'm not sure if there's a wider impact to this fix nor if there's a more rigorous fix for this.