### PR TITLE
fix(deps): update eslint to version where minimap dep > 3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "test": "nyc --reporter=html --reporter=lcov mocha -R spec"
   },
   "dependencies": {
-    "eslint": "^7.32.0"
+    "eslint": "^8.15.0"
   }
 }


### PR DESCRIPTION
Currently, the version of eslint used by rewire has a vulnerable dependency - eslint v7.32.0
Updating to version v8.15.0 would resolve eslints dependency on v3.0.4 of minimatch
 
NPM High Vulnerability: minimatch.js braceExpand() Function Improper | Regular Expression DoS