### PR TITLE
use pirates for proper load extensions install/uninstall handling

### DIFF
--- a/lib/moduleEnv.js
+++ b/lib/moduleEnv.js
@@ -1,13 +1,11 @@
 "use strict";
 
-// TODO: Use https://www.npmjs.com/package/pirates here?
-
 var Module = require("module"),
+    pirates = require("pirates"),
     eslint = require("eslint");
 
 var moduleWrapper0 = Module.wrapper[0],
     moduleWrapper1 = Module.wrapper[1],
-    originalExtensions = {},
     linter = new eslint.Linter(),
     eslintOptions = {
         languageOptions: {
@@ -50,9 +48,11 @@ function load(targetModule) {
     targetModule.require = requireProxy;
     currentModule = targetModule;
 
-    registerExtensions();
+    var restoreExtensions = pirates.addHook(patchSources, { extensions: ['.js', '.cjs', '.mjs', '.ts']});
+
     targetModule.load(targetModule.id);
 
+    restoreExtensions();
     // This is only necessary if nothing has been required within the module
     reset();
 }
@@ -79,84 +79,24 @@ function requireProxy(path) {
     return nodeRequire.call(currentModule, path);  // node's require only works when "this" points to the module
 }
 
-function registerExtensions() {
-    var originalJsExtension = require.extensions[".js"];
-    var originalTsExtension = require.extensions[".ts"];
-
-    if (originalJsExtension) {
-        originalExtensions.js = originalJsExtension;
-    }
-    if (originalTsExtension) {
-        originalExtensions.ts = originalTsExtension;
-    }
-    require.extensions[".js"] = jsExtension;
-    require.extensions[".ts"] = tsExtension;
-}
-
-function restoreExtensions() {
-    if ("js" in originalExtensions) {
-        require.extensions[".js"] = originalExtensions.js;
-    }
-    if ("ts" in originalExtensions) {
-        require.extensions[".ts"] = originalExtensions.ts;
-    }
-}
-
 function isNoConstAssignMessage(message) {
     return message.ruleId === "no-const-assign";
 }
 
-function jsExtension(module, filename) {
-    var _compile = module._compile;
+function patchSources(content, filename) {
+    var noConstAssignMessage = linter.verify(content, eslintOptions).find(isNoConstAssignMessage);
+    var line;
+    var column;
 
-    module._compile = function (content, filename) {
-        var noConstAssignMessage = linter.verify(content, eslintOptions).find(isNoConstAssignMessage);
-        var line;
-        var column;
+    if (noConstAssignMessage !== undefined) {
+        line = noConstAssignMessage.line;
+        column = noConstAssignMessage.column;
+        throw new TypeError(`Assignment to constant variable at ${filename}:${line}:${column}`);
+    }
 
-        if (noConstAssignMessage !== undefined) {
-            line = noConstAssignMessage.line;
-            column = noConstAssignMessage.column;
-            throw new TypeError(`Assignment to constant variable at ${filename}:${line}:${column}`);
-        }
-
-        _compile.call(
-            module,
-            content
-                .replace(shebang, '') // Remove shebang declarations
-                .replace(matchConst, "$1let  $2"), // replace const with let, while maintaining the column width
-            filename
-        );
-    };
-
-    restoreExtensions();
-    originalExtensions.js(module, filename);
-}
-
-function tsExtension(module, filename) {
-    var _compile = module._compile;
-
-    module._compile = function rewireCompile(content, filename) {
-        var noConstAssignMessage = linter.verify(content, eslintOptions).find(isNoConstAssignMessage);
-        var line;
-        var column;
-
-        if (noConstAssignMessage !== undefined) {
-            line = noConstAssignMessage.line;
-            column = noConstAssignMessage.column;
-            throw new TypeError(`Assignment to constant variable at ${filename}:${line}:${column}`);
-        }
-        _compile.call(
-            this,
-            content
-                .replace(shebang, '') // Remove shebang declarations
-                .replace(matchConst, "$1let  $2"), // replace const with let, while maintaining the column width
-            filename
-        );
-    };
-
-    restoreExtensions();
-    originalExtensions.ts(module, filename);
+    return content
+        .replace(shebang, '') // Remove shebang declarations
+        .replace(matchConst, "$1let  $2"); // replace const with let, while maintaining the column width
 }
 
 exports.load = load;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "rewire",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rewire",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "eslint": "^9.30"
+        "eslint": "^9.30",
+        "pirates": "^4.0.7"
       },
       "devDependencies": {
         "@types/node": "^22.15.21",
@@ -2708,6 +2709,15 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test": "nyc --reporter=html --reporter=lcov mocha -r ts-node/register -R spec"
   },
   "dependencies": {
-    "eslint": "^9.30"
+    "eslint": "^9.30",
+    "pirates": "^4.0.7"
   },
   "files": [
     "lib"


### PR DESCRIPTION
This fixes a probably rare (though i face it a lot) problem with a recursive loop in `restoreExtensions`, when `ts` extension installed by one `rewire` instance (and not yet restored) is saved to `originalExtensions.ts` by another one, leading to recursion in `registerExtensions -> tsExtension -> restoreExtensions` and eventual `RangeError: Maximum call stack size exceeded` error. 


The problem can be easily reproduced if ts-node is omitted to run tests, for example. 
```
> mocha
  ....
  65 passing (277ms)
  1 failing

  1) rewire
       should work with TypeScript:
  RangeError: Maximum call stack size exceeded
    at Object.tsExtension [as ts] (lib/moduleEnv.js:136:21)
    at Object.tsExtension [as ts] (lib/moduleEnv.js:159:24)
    at Object.tsExtension [as ts] (lib/moduleEnv.js:159:24)
    ...
    ... few more thousand of the same text
    ...
    at Object.tsExtension [as .ts] (lib/moduleEnv.js:159:24)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Object.load (lib/moduleEnv.js:54:18)
    at internalRewire (lib/rewire.js:49:15)
    at rewire (lib/index.js:11:12)
    at Context.<anonymous> (test/rewire.test.js:23:20)
    at process.processImmediate (node:internal/timers:476:21)
```

It also happens if you use `require(esm)` in some cases, though it is way harder to reproduce it reliably.
With this patch it never happens :) ("should work with TypeScript" will still fail w/o ts-node, yet it will be way more trivial reason :) )

Also, this is a groundwork to make rewire ESM-compatible (thanks to require(esm), esbuild, and some AST magic). 
Though, esm-compatibility is a subject for another PR and probably a major version bump. Anyway, it is not yet ready to be shared, so i'll get back to you with esm support ready to merge abit later, i hope :")

I did my best to align changes with local style conventions, please accept :)

TIA